### PR TITLE
Add optional scopinator integration hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,25 @@ Github source
 Releases, and notes can be found on github at:
 <https://github.com/smart-underworld/seestar_alp/releases>
 
+## Optional scopinator integration
+
+Seestar ALP can optionally delegate certain telescope commands to the
+[scopinator](https://github.com/astrophotograph/pyscopinator) project when that
+library is installed in the Python environment.  This can help reuse existing
+client implementations or serve as a fallback transport when the native socket
+connection is unreliable.
+
+To enable the integration update `device/config.toml`:
+
+```toml
+[device]
+use_scopinator = true          # enable the dynamic integration
+scopinator_prefer = false      # leave false to prefer the built-in socket transport
+scopinator_timeout = 15        # timeout (seconds) for synchronous scopinator calls
+```
+
+The same keys can be added to individual `[[seestars]]` entries to override the
+defaults on a per-device basis.  When the module cannot be imported the driver
+falls back to the existing socket implementation and logs an informational
+message at startup.
+

--- a/change_log.txt
+++ b/change_log.txt
@@ -1,5 +1,10 @@
 Change Log
 
+Unreleased
+----------
+- Added optional scopinator integration with configuration toggles and runtime
+  fallbacks when the library is available.
+
 Version 1.0.0.a4 - June 22, 2024
 Added retry to connection to seestar
 

--- a/device/app.py
+++ b/device/app.py
@@ -234,7 +234,19 @@ class DeviceMain:
 
         for dev in Config.seestars:
             is_EQ_mode = dev.get('is_EQ_mode', Config.is_EQ_mode)
-            controller = telescope.start_seestar_device(logger, dev['name'], dev['ip_address'], 4700, dev['device_num'], is_EQ_mode)
+            use_scopinator = dev.get('use_scopinator', Config.use_scopinator)
+            scopinator_prefer = dev.get('scopinator_prefer', Config.scopinator_prefer)
+            controller = telescope.start_seestar_device(
+                logger,
+                dev['name'],
+                dev['ip_address'],
+                4700,
+                dev['device_num'],
+                is_EQ_mode,
+                use_scopinator,
+                scopinator_prefer,
+                Config.scopinator_timeout,
+            )
             telescope.start_seestar_imaging(logger, dev['name'], dev['ip_address'], 4800, dev['device_num'], controller)
             telescope.start_seestar_logcollector(logger, dev['name'], dev['ip_address'], 4801, dev['device_num'], controller)
 

--- a/device/config.py
+++ b/device/config.py
@@ -137,6 +137,9 @@ class _Config:
         self.can_reverse: bool = self.get_toml('device', 'can_reverse', True)
         self.step_size: float = self.get_toml('device', 'step_size', 1.0)
         self.steps_per_sec: int = self.get_toml('device', 'steps_per_sec', 6)
+        self.use_scopinator: bool = self.get_toml('device', 'use_scopinator', False)
+        self.scopinator_prefer: bool = self.get_toml('device', 'scopinator_prefer', False)
+        self.scopinator_timeout: int = self.get_toml('device', 'scopinator_timeout', 15)
         if 'seestars' in self._dict:
             self.seestars = self._dict['seestars']
         else:
@@ -161,6 +164,8 @@ class _Config:
                 for ss in self.seestars:
                     ss['device_num'] = counter
                     counter += 1
+            seestar.setdefault('use_scopinator', self.use_scopinator)
+            seestar.setdefault('scopinator_prefer', self.scopinator_prefer)
 
 
         # ---------------

--- a/device/config.toml.example
+++ b/device/config.toml.example
@@ -26,6 +26,9 @@ verbose_driver_exceptions = true
 can_reverse = true
 step_size = 1.0
 steps_per_sec = 6
+use_scopinator = false              # enable optional integration with the scopinator library when available
+scopinator_prefer = false           # if true, scopinator will be used before the native socket transport
+scopinator_timeout = 15             # seconds to wait for scopinator synchronous calls
 
 
 [seestar_initialization]
@@ -61,6 +64,8 @@ name = "Seestar Alpha"
 # ip_address should not have to be changed unless you have more than 1 seestar
 ip_address = "seestar.local"
 device_num = 1
+#use_scopinator = true             # uncomment to override the global setting for a specific device
+#scopinator_prefer = true          # uncomment to have this device prefer scopinator calls over the socket transport
 # You can specify the following settings to override those found in the seestar_initialization section on a per-device level
 #move_arm_lat_sec = 2           # start up raise arm setting for moving up/down from zenith in movement clock seconds, from -20 to 20
 #move_arm_lon_sec = 20          # start up raise arm setting for moving counter/clockwise from zenith in movement clock seconds, from -100 to 100

--- a/device/scopinator_bridge.py
+++ b/device/scopinator_bridge.py
@@ -1,0 +1,395 @@
+"""Optional integration helpers for the external scopinator project."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from types import ModuleType
+from typing import Any, Callable, Iterable, Optional, Sequence
+
+
+class ScopinatorNotAvailableError(RuntimeError):
+    """Raised when scopinator cannot be imported or instantiated."""
+
+
+class ScopinatorCallError(RuntimeError):
+    """Raised when a scopinator call fails."""
+
+
+class ScopinatorBridge:
+    """Dynamically integrate with the optional scopinator package.
+
+    The scopinator project changed names a few times (``scopinator`` vs
+    ``pyscopinator``) and the public surface is still in flux.  This bridge uses
+    a collection of heuristics so that we can take advantage of any compatible
+    installation without taking a hard dependency on a specific release.
+    """
+
+    _MODULE_NAMES: Sequence[str] = ("scopinator", "pyscopinator")
+    _SUBMODULE_NAMES: Sequence[str] = ("client", "api", "core", "device")
+    _CONSTRUCTOR_NAMES: Sequence[str] = (
+        "SeestarClient",
+        "Seestar",
+        "ScopinatorClient",
+        "ScopeClient",
+        "Scope",
+        "Client",
+        "Controller",
+        "Connection",
+    )
+    _FUNCTION_CONSTRUCTORS: Sequence[str] = (
+        "create_client",
+        "make_client",
+        "get_client",
+        "connect",
+        "open_connection",
+    )
+    _SYNC_NAMES: Sequence[str] = (
+        "call_sync",
+        "method_sync",
+        "call",
+        "request",
+        "send_sync",
+        "execute",
+        "invoke",
+        "send_request",
+    )
+    _ASYNC_NAMES: Sequence[str] = (
+        "call_async",
+        "method_async",
+        "send_async",
+        "queue",
+        "enqueue",
+        "execute_async",
+        "request_async",
+    )
+    _RAW_NAMES: Sequence[str] = (
+        "send",
+        "send_raw",
+        "send_message",
+        "send_json",
+        "write",
+        "emit",
+    )
+
+    def __init__(
+        self,
+        logger,
+        host: str,
+        port: int,
+        device_name: str,
+        *,
+        prefer: bool = False,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self.logger = logger
+        self.host = host
+        self.port = port
+        self.device_name = device_name
+        self.prefer = prefer
+        self.timeout = timeout
+
+        self._module = self._import_module()
+        self._client = self._create_client(self._module)
+        self._sync_callables = self._collect_callables(self._SYNC_NAMES)
+        self._async_callables = self._collect_callables(self._ASYNC_NAMES)
+        self._raw_callables = self._collect_callables(self._RAW_NAMES)
+
+        if not self._sync_callables and self._async_callables:
+            # Allow using async callables as a synchronous fallback.
+            self._sync_callables = list(self._async_callables)
+
+        if not (self._sync_callables or self._async_callables or self._raw_callables):
+            raise ScopinatorNotAvailableError(
+                "scopinator module was located but no compatible call interfaces were found"
+            )
+
+        self.logger.info(
+            "Scopinator integration enabled for %s using %s",
+            self.device_name,
+            type(self._client).__name__,
+        )
+
+    # ------------------------------------------------------------------
+    # public helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def create(
+        cls,
+        logger,
+        host: str,
+        port: int,
+        device_name: str,
+        *,
+        prefer: bool = False,
+        timeout: Optional[float] = None,
+    ) -> Optional["ScopinatorBridge"]:
+        try:
+            return cls(logger, host, port, device_name, prefer=prefer, timeout=timeout)
+        except ScopinatorNotAvailableError as exc:
+            logger.info("Scopinator integration unavailable: %s", exc)
+            return None
+
+    def is_ready(self) -> bool:
+        return self._client is not None
+
+    # synchronous ------------------------------------------------------
+    def call_sync(self, payload: dict[str, Any]) -> Any:
+        return self._invoke_candidates(self._sync_callables, payload, wait=True)
+
+    # asynchronous -----------------------------------------------------
+    def call_async(self, payload: dict[str, Any]) -> Any:
+        try:
+            return self._invoke_candidates(self._async_callables, payload, wait=False)
+        except ScopinatorCallError:
+            # Fallback to synchronous if no dedicated async call exists.
+            return self._invoke_candidates(self._sync_callables, payload, wait=False)
+
+    # raw --------------------------------------------------------------
+    def send_raw(self, data: str) -> Any:
+        payload = {"method": None, "raw": data}
+        return self._invoke_candidates(self._raw_callables, payload, wait=False)
+
+    # ------------------------------------------------------------------
+    # dynamic discovery helpers
+    # ------------------------------------------------------------------
+    def _import_module(self) -> ModuleType:
+        last_exc: Optional[Exception] = None
+        for name in self._MODULE_NAMES:
+            try:
+                return importlib.import_module(name)
+            except ImportError as exc:  # pragma: no cover - best effort
+                last_exc = exc
+        raise ScopinatorNotAvailableError("scopinator package is not installed") from last_exc
+
+    def _related_modules(self) -> Iterable[ModuleType]:
+        visited: set[str] = set()
+        modules: list[ModuleType] = []
+        base_modules: list[ModuleType] = []
+
+        if self._module:
+            modules.append(self._module)
+            base_modules.append(self._module)
+            visited.add(self._module.__name__)
+
+        base_name = self._module.__name__.split(".")[0]
+        for suffix in self._SUBMODULE_NAMES:
+            try:
+                mod = importlib.import_module(f"{base_name}.{suffix}")
+            except ImportError:  # pragma: no cover - optional modules
+                continue
+            if mod.__name__ not in visited:
+                modules.append(mod)
+                visited.add(mod.__name__)
+
+        return modules
+
+    def _iter_candidate_ctors(self, module: ModuleType) -> Iterable[type]:
+        seen: set[type] = set()
+        for name in self._CONSTRUCTOR_NAMES:
+            attr = getattr(module, name, None)
+            if inspect.isclass(attr) and attr not in seen:
+                seen.add(attr)
+                yield attr
+
+    def _create_client(self, module: ModuleType):
+        errors: list[str] = []
+        for mod in self._related_modules():
+            for ctor in self._iter_candidate_ctors(mod):
+                client = self._try_instantiate(ctor, errors)
+                if client:
+                    self._connect_client(client)
+                    return client
+
+            for func_name in self._FUNCTION_CONSTRUCTORS:
+                func = getattr(mod, func_name, None)
+                if callable(func):
+                    client = self._try_constructor_function(func, errors)
+                    if client:
+                        self._connect_client(client)
+                        return client
+
+        raise ScopinatorNotAvailableError(
+            "unable to locate a compatible scopinator client constructor: "
+            + "; ".join(errors) if errors else "unknown reason"
+        )
+
+    def _try_constructor_function(self, func: Callable[..., Any], errors: list[str]):
+        attempts = [
+            {"host": self.host, "port": self.port, "timeout": self.timeout},
+            {"ip": self.host, "port": self.port, "timeout": self.timeout},
+            {"address": self.host, "port": self.port},
+            {"base_url": f"http://{self.host}:{self.port}"},
+            {},
+        ]
+        for kwargs in attempts:
+            clean_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+            try:
+                return func(**clean_kwargs)
+            except TypeError:
+                continue
+            except Exception as exc:  # pragma: no cover - best effort
+                errors.append(f"{func.__name__}: {exc}")
+                break
+        return None
+
+    def _try_instantiate(self, ctor: type, errors: list[str]):
+        kwargs_attempts = [
+            {"host": self.host, "port": self.port, "timeout": self.timeout, "logger": self.logger},
+            {"host": self.host, "port": self.port, "timeout": self.timeout},
+            {"host": self.host, "port": self.port},
+            {"address": self.host, "port": self.port},
+            {"ip": self.host, "port": self.port},
+            {"hostname": self.host, "port": self.port},
+            {"base_url": f"http://{self.host}:{self.port}"},
+            {},
+        ]
+        for kwargs in kwargs_attempts:
+            clean_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+            try:
+                return ctor(**clean_kwargs)
+            except TypeError:
+                continue
+            except Exception as exc:  # pragma: no cover - best effort
+                errors.append(f"{ctor.__name__}: {exc}")
+                break
+
+        args_attempts = [
+            (self.host, self.port, self.logger),
+            (self.host, self.port),
+            (self.host,),
+            (),
+        ]
+        for args in args_attempts:
+            try:
+                return ctor(*args)
+            except TypeError:
+                continue
+            except Exception as exc:  # pragma: no cover - best effort
+                errors.append(f"{ctor.__name__}: {exc}")
+                break
+        return None
+
+    def _connect_client(self, client: Any) -> None:
+        for name in ("connect", "open", "start", "ensure_connection", "ensure_connected"):
+            method = getattr(client, name, None)
+            if callable(method):
+                try:
+                    method()
+                    return
+                except TypeError:
+                    try:
+                        method(self.host, self.port)
+                        return
+                    except Exception:  # pragma: no cover - best effort
+                        continue
+                except Exception:  # pragma: no cover - best effort
+                    continue
+
+    def _collect_callables(self, names: Sequence[str]) -> list[Callable[..., Any]]:
+        callables: list[Callable[..., Any]] = []
+        sources: list[Any] = [self._client]
+        sources.extend(self._related_modules())
+        for source in sources:
+            if source is None:
+                continue
+            for name in names:
+                attr = getattr(source, name, None)
+                if callable(attr) and attr not in callables:
+                    callables.append(attr)
+        return callables
+
+    # ------------------------------------------------------------------
+    # invocation helpers
+    # ------------------------------------------------------------------
+    def _invoke_candidates(
+        self,
+        candidates: Sequence[Callable[..., Any]],
+        payload: dict[str, Any],
+        *,
+        wait: bool,
+    ) -> Any:
+        if not candidates:
+            raise ScopinatorCallError("no callable candidates available")
+
+        errors: list[str] = []
+        for func in candidates:
+            try:
+                result = self._invoke_callable(func, payload, wait=wait)
+            except TypeError as exc:
+                errors.append(f"{func.__name__}: {exc}")
+                continue
+            except Exception as exc:  # pragma: no cover - best effort
+                errors.append(f"{func.__name__}: {exc}")
+                continue
+            return self._normalise_result(result)
+
+        raise ScopinatorCallError("; ".join(errors))
+
+    def _invoke_callable(self, func: Callable[..., Any], payload: dict[str, Any], *, wait: bool) -> Any:
+        method = payload.get("method")
+        params = payload.get("params")
+        message_id = payload.get("id")
+        raw = payload.get("raw")
+
+        base_kwargs = {}
+        if self.timeout is not None:
+            base_kwargs["timeout"] = self.timeout
+        if wait is not None:
+            base_kwargs["wait"] = wait
+
+        attempts: list[Callable[[], Any]] = []
+        if method is not None:
+            attempts.extend(
+                [
+                    lambda: func(method, params=params, message_id=message_id, **base_kwargs),
+                    lambda: func(method, params=params, id=message_id, **base_kwargs),
+                    lambda: func(method, params=params, **base_kwargs),
+                    lambda: func(method, message_id=message_id, **base_kwargs),
+                    lambda: func(method, **base_kwargs),
+                ]
+            )
+
+            if isinstance(params, dict):
+                attempts.append(lambda: func(method, **params))
+                attempts.append(lambda: func(method, **params, **base_kwargs))
+            elif isinstance(params, (list, tuple)):
+                attempts.append(lambda: func(method, *params))
+
+            attempts.append(lambda: func({k: v for k, v in payload.items() if k != "raw"}))
+            attempts.append(lambda: func(json.dumps({k: v for k, v in payload.items() if k != "raw"})))
+        elif raw is not None:
+            attempts.append(lambda: func(raw))
+
+        attempts.append(lambda: func(payload))
+
+        for attempt in attempts:
+            try:
+                return attempt()
+            except TypeError:
+                continue
+
+        raise TypeError("no compatible signature found for scopinator callable")
+
+    def _normalise_result(self, result: Any) -> Any:
+        if result is None:
+            return None
+        if isinstance(result, (bytes, bytearray)):
+            try:
+                return json.loads(result.decode("utf-8"))
+            except Exception:  # pragma: no cover - best effort
+                return result
+        if isinstance(result, str):
+            try:
+                return json.loads(result)
+            except json.JSONDecodeError:
+                return {"result": result}
+        return result
+
+
+__all__ = [
+    "ScopinatorBridge",
+    "ScopinatorCallError",
+    "ScopinatorNotAvailableError",
+]

--- a/device/seestar_device.py
+++ b/device/seestar_device.py
@@ -29,6 +29,7 @@ from device.config import Config
 from device.version import Version # type: ignore
 from device.seestar_util import Util
 from device.event_callbacks import *
+from device.scopinator_bridge import ScopinatorBridge, ScopinatorCallError
 
 from collections import OrderedDict
 
@@ -76,8 +77,20 @@ class Seestar:
         return super().__new__(cls)
 
     # <ip_address> <port> <device name> <device num>
-    def __init__(self, logger, host: str, port: int, device_name: str, device_num: int, is_EQ_mode: bool,
-                 is_debug=False):
+    def __init__(
+        self,
+        logger,
+        host: str,
+        port: int,
+        device_name: str,
+        device_num: int,
+        is_EQ_mode: bool,
+        is_debug=False,
+        *,
+        use_scopinator: bool = False,
+        scopinator_prefer: bool = False,
+        scopinator_timeout: int = 15,
+    ):
         logger.info(
             f"Initialize the new instance of Seestar: {host}:{port}, name:{device_name}, num:{device_num}, is_EQ_mode:{is_EQ_mode}, is_debug:{is_debug}")
 
@@ -96,6 +109,10 @@ class Seestar:
         self.get_msg_thread: Optional[threading.Thread] = None
         self.heartbeat_msg_thread: Optional[threading.Thread] = None
         self.is_debug: bool = is_debug
+        self.use_scopinator: bool = use_scopinator
+        self.scopinator_prefer: bool = scopinator_prefer
+        self.scopinator_timeout: int = scopinator_timeout
+        self._scopinator_bridge = None
         self.response_dict: OrderedDict[int, dict] = FixedSizeOrderedDict(max=100)
         self.logger = logger
         self.is_connected: bool = False
@@ -140,6 +157,21 @@ class Seestar:
         self.is_EQ_mode: bool = is_EQ_mode
         # self.trace = MessageTrace(self.device_num, self.port)
 
+        if self.use_scopinator:
+            self._scopinator_bridge = ScopinatorBridge.create(
+                logger,
+                host,
+                port,
+                device_name,
+                prefer=scopinator_prefer,
+                timeout=scopinator_timeout,
+            )
+            if self._scopinator_bridge is None:
+                self.logger.info(
+                    "Scopinator integration requested for %s but is not available; falling back to socket transport",
+                    self.device_name,
+                )
+
     # scheduler state example: {"state":"working", "schedule_id":"abcdefg",
     #       "result":0, "error":"dummy error",
     #       "cur_schedule_item":{   "type":"mosaic", "schedule_item_GUID":"abcde", "state":"working",
@@ -176,11 +208,15 @@ class Seestar:
             if self.s is None:
                 self.logger.warn("socket not initialized!")
                 time.sleep(3)
+                if self._try_scopinator_raw(data):
+                    return True
                 return False
             # todo : don't send if not connected or socket is null?
             self.s.sendall(data.encode())  # TODO: would utf-8 or unicode_escaped help here
             return True
         except socket.timeout:
+            if self._try_scopinator_raw(data):
+                return True
             return False
         except socket.error as e:
             # Don't bother trying to recover if watch events is False
@@ -188,9 +224,13 @@ class Seestar:
             self.disconnect()
             if self.is_watch_events and self.reconnect():
                 return self.send_message(data)
+            if self._try_scopinator_raw(data):
+                return True
             return False
         except:
             self.logger.error(f"General error trying to send message: ", data)
+            if self._try_scopinator_raw(data):
+                return True
             return False
 
     def socket_force_close(self) -> None:
@@ -395,27 +435,76 @@ class Seestar:
                     first_index = msg_remainder.find("\r\n")
             time.sleep(0.1)
 
+    def _log_outgoing(self, method: Optional[str], json_data: str) -> None:
+        if method == 'scope_get_equ_coord':
+            self.logger.debug(f'sending: {json_data}')
+        else:
+            self.logger.debug(f'sending: {json_data}')
+
+    def _prepare_command_payload(self, data: MessageParams) -> tuple[dict[str, Any], int, str]:
+        payload = dict(data)
+        cur_cmdid = payload.get('id') or self.cmdid
+        payload['id'] = cur_cmdid
+        data['id'] = cur_cmdid
+        self.cmdid += 1
+        json_data = json.dumps(payload)
+        self._log_outgoing(payload.get('method'), json_data)
+        return payload, cur_cmdid, json_data
+
+    def _try_scopinator_raw(self, data: str) -> bool:
+        if not self._scopinator_bridge:
+            return False
+        try:
+            self._scopinator_bridge.send_raw(data)
+            return True
+        except ScopinatorCallError as exc:
+            self.logger.debug(f"Scopinator raw send failed: {exc}")
+            return False
+
+    def _try_scopinator_async(self, payload: dict[str, Any]) -> bool:
+        if not self._scopinator_bridge:
+            return False
+        try:
+            self._scopinator_bridge.call_async(payload)
+            return True
+        except ScopinatorCallError as exc:
+            self.logger.warning(f"Scopinator async call failed: {exc}")
+            return False
+
+    def _try_scopinator_sync(self, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+        if not self._scopinator_bridge:
+            return None
+        try:
+            result = self._scopinator_bridge.call_sync(payload)
+            if isinstance(result, dict):
+                return result
+            if result is None:
+                return None
+            return {"result": result}
+        except ScopinatorCallError as exc:
+            self.logger.warning(f"Scopinator sync call failed: {exc}")
+            return None
+
     def json_message(self, instruction: str, **kwargs):
         data = {"id": self.cmdid, "method": instruction, **kwargs}
         self.cmdid += 1
         json_data = json.dumps(data)
-        if instruction == 'scope_get_equ_coord':
-            self.logger.debug(f'sending: {json_data}')
-        else:
-            self.logger.debug(f'sending: {json_data}')
+        self._log_outgoing(instruction, json_data)
         self.send_message(json_data + "\r\n")
 
     def send_message_param(self, data: MessageParams) -> int:
-        cur_cmdid = data.get('id') or self.cmdid
-        data['id'] = cur_cmdid
-        self.cmdid += 1  # can this overflow?  not in JSON...
-        json_data = json.dumps(data)
-        if 'method' in data and data['method'] == 'scope_get_equ_coord':
-            self.logger.debug(f'sending: {json_data}')
-        else:
-            self.logger.debug(f'sending: {json_data}')
+        payload, cur_cmdid, json_data = self._prepare_command_payload(data)
 
-        self.send_message(json_data + "\r\n")
+        sent = False
+        if self.scopinator_prefer and self._try_scopinator_async(payload):
+            sent = True
+
+        if not sent:
+            sent = self.send_message(json_data + "\r\n")
+
+        if not sent and not self.scopinator_prefer:
+            self._try_scopinator_async(payload)
+
         return cur_cmdid
 
     def shut_down_thread(self, data):
@@ -429,11 +518,25 @@ class Seestar:
         cur_cmdid = self.send_message_param(data)
 
     def send_message_param_sync(self, data: MessageParams):
-        if data['method'] == 'pi_shutdown' or data['method'] == 'pi_reboot':
+        method_name = data.get('method')
+        if method_name in ['pi_shutdown', 'pi_reboot']:
             threading.Thread(name=f"shutdown-thread:{self.device_name}", target=lambda: self.shut_down_thread(data)).start()
-            return {'method': data['method'], 'result': "Sent command async for these types of commands." }
-        else:
-            cur_cmdid = self.send_message_param(data)
+            return {'method': method_name, 'result': "Sent command async for these types of commands." }
+
+        payload, cur_cmdid, json_data = self._prepare_command_payload(data)
+
+        if self.scopinator_prefer:
+            result = self._try_scopinator_sync(payload)
+            if result is not None:
+                self.response_dict[cur_cmdid] = result
+                return result
+
+        sent = self.send_message(json_data + "\r\n")
+        if not sent:
+            fallback = self._try_scopinator_sync(payload)
+            if fallback is not None:
+                self.response_dict[cur_cmdid] = fallback
+                return fallback
 
         start = time.time()
         last_slow = start
@@ -443,15 +546,22 @@ class Seestar:
                 elapsed = now - start
                 last_slow = now
                 if elapsed > 10:
-                    self.logger.error(f'Failed to wait for message response.  {elapsed} seconds. {cur_cmdid=} {data=}')
-                    data['result'] = "Error: Exceeded allotted wait time for result"
-                    return data
+                    self.logger.error(f'Failed to wait for message response.  {elapsed} seconds. {cur_cmdid=} {payload=}')
+                    if not self.scopinator_prefer:
+                        alt = self._try_scopinator_sync(payload)
+                        if alt is not None:
+                            self.response_dict[cur_cmdid] = alt
+                            return alt
+                    payload['result'] = "Error: Exceeded allotted wait time for result"
+                    return payload
                 else:
-                    self.logger.warn(f'SLOW message response.  {elapsed} seconds. {cur_cmdid=} {data=}')
+                    self.logger.warn(f'SLOW message response.  {elapsed} seconds. {cur_cmdid=} {payload=}')
                     # todo : dump out stats.  last run time on threads, connection status, etc.
             time.sleep(0.5)
-        self.logger.debug(f'response is {self.response_dict[cur_cmdid]}')
-        return self.response_dict[cur_cmdid]
+
+        response = self.response_dict[cur_cmdid]
+        self.logger.debug(f'response is {response}')
+        return response
 
     def get_event_state(self, params=None):
         self.event_state["scheduler"]["Event"] = "Scheduler"

--- a/device/telescope.py
+++ b/device/telescope.py
@@ -67,10 +67,31 @@ def start_seestar_federation(logger: logger): # type: ignore
     global seestar_federation
     seestar_federation = Seestar_Federation(logger, seestar_dev)
 
-def start_seestar_device(logger: logger, name: str, ip_address: str, port: int, device_num: int, is_EQ_mode: bool): # type: ignore
+def start_seestar_device(
+    logger: logger,
+    name: str,
+    ip_address: str,
+    port: int,
+    device_num: int,
+    is_EQ_mode: bool,
+    use_scopinator: bool,
+    scopinator_prefer: bool,
+    scopinator_timeout: int,
+):  # type: ignore
     # logger = logger
     global seestar_dev
-    seestar_dev[device_num] = Seestar(logger, ip_address, port, name, device_num, is_EQ_mode, True)
+    seestar_dev[device_num] = Seestar(
+        logger,
+        ip_address,
+        port,
+        name,
+        device_num,
+        is_EQ_mode,
+        True,
+        use_scopinator=use_scopinator,
+        scopinator_prefer=scopinator_prefer,
+        scopinator_timeout=scopinator_timeout,
+    )
     seestar_dev[device_num].start_watch_thread()
     return seestar_dev[device_num]
 


### PR DESCRIPTION
## Summary
- add configuration toggles and documentation for enabling optional scopinator usage
- introduce a dynamic ScopinatorBridge adapter and hook Seestar command paths to use it when available
- extend startup wiring so each telescope instance can opt into scopinator support

## Testing
- python -m compileall device/scopinator_bridge.py device/seestar_device.py

------
https://chatgpt.com/codex/tasks/task_e_68efbe0d850c83229b8172d39400eabb